### PR TITLE
Improve Kafka reliability and centralize configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,15 +195,21 @@ Retriever Service
 **Environment variables (examples):**
 
 *   KAFKA\_BOOTSTRAP\_SERVERS
-    
+
 *   MONGO\_URI
-    
+
 *   ELASTIC\_URL
-    
+
 *   AUDIO\_PATH
-    
+
 *   (others defined in config.yaml)
-    
+
+**Batching and offsets**
+
+Kafka consumers poll up to `kafka.consumer_batch_size` records and commit offsets
+manually after each batch. This prevents reprocessing and enables efficient bulk
+indexing.
+
 
 **Commands:**
 

--- a/dal/mongo_dal.py
+++ b/dal/mongo_dal.py
@@ -1,20 +1,33 @@
-
-import json
+from pathlib import Path
 from shared.connectors.mongo_connector import Mongo_Connector
+from shared.utils.logger import logger
+
 
 class Mongo_Dal:
-    """
-    A class that manages all queries with the DB
-    """
+    """A class that manages all queries with the DB"""
 
-    def __init__(self,coll):
-        self.coll = coll
+    def __init__(self):
+        # Initialize collection and GridFS bucket via shared connector
+        self.coll = Mongo_Connector.get_mongo_collection()
+        self.fs = Mongo_Connector.get_gridfs_bucket()
 
-    def insert_doc(self,doc: dict):
-        col = self.coll
-        return col.insert_one(doc)
+    def insert_doc(self, doc: dict):
+        return self.coll.insert_one(doc)
 
     def get_all_docs(self):
-        col = self.coll
-        return list(col.find().limit(20))
+        return list(self.coll.find().limit(20))
 
+    def store_file(self, file_id: str, abs_path: str, filename: str, replace: bool = True):
+        """Store a local file in GridFS via the DAL."""
+        p = Path(abs_path)
+        if not (p.exists() and p.is_file()):
+            logger.warning(f"File not found: {abs_path}")
+            return
+        if replace and self.fs.exists({"_id": file_id}):
+            self.fs.delete(file_id)
+        with p.open("rb") as fh:
+            kwargs = {"_id": file_id}
+            if filename:
+                kwargs["filename"] = filename
+            self.fs.put(fh, **kwargs)
+        logger.info(f"Stored file in GridFS (id={file_id}, name={filename or p.name})")

--- a/services/mongo_writer_service/src/service.py
+++ b/services/mongo_writer_service/src/service.py
@@ -1,10 +1,7 @@
 from shared.connectors.kafka_connector import Kafka_Connector
 from shared.utils.config_loader import load_config
 from shared.utils.logger import logger
-
-from pymongo import MongoClient
-from gridfs import GridFS
-from pathlib import Path
+from dal.mongo_dal import Mongo_Dal
 import time
 
 
@@ -12,36 +9,37 @@ class MongoWriter:
     def __init__(self):
         config = load_config()
         self.topic = config["kafka"]["topics"]["raw_metadata"]
+        self.group_id = "mongowriter-metadata-group"
+        self.batch_size = config["kafka"].get("consumer_batch_size", 50)
+        self.timeout_ms = config["kafka"].get("consumer_timeout_ms", 1000)
 
-        # Kafka consumer without timeout
-        self.consumer = Kafka_Connector.get_consumer(self.topic ,group_id="Mongowriter-metadata-group")
+        # Kafka consumer with manual commit
+        self.consumer = Kafka_Connector.get_consumer(self.topic, group_id=self.group_id)
 
-        # Build Mongo + GridFS connection (later will use the Mongo_Connector tu build)
-        mongo_uri = config["mongo"]["uri"]
-        db_name = config.get("mongo").get("db")
-        bucket_name = config.get("mongo").get("gridfs_bucket", "fs")
-
-        self.client = MongoClient(mongo_uri)
-        self.db = self.client[db_name]
-        self.fs = GridFS(self.db, collection=bucket_name)
+        # Use Mongo DAL for all DB interactions
+        self.dal = Mongo_Dal()
 
 
     def run(self):
         logger.info("MongoWriter started: waiting for Kafka messages...")
         while True:
             try:
-                for msg in self.consumer:
-                    doc = msg.value
-                    abs_path = doc.get("absolute_path")
-                    # Ensure each doc has the field of absolute path
-                    if not abs_path:
-                        logger.warning("Skipping message without absolute_path")
-                        continue
-
-                    file_id = abs_path
-                    filename = doc.get("name")
-
-                    self._store_file(file_id, abs_path, filename)
+                records = self.consumer.poll(timeout_ms=self.timeout_ms, max_records=self.batch_size)
+                if not records:
+                    continue
+                for msgs in records.values():
+                    for msg in msgs:
+                        doc = msg.value
+                        abs_path = doc.get("absolute_path")
+                        # Ensure each doc has the field of absolute path
+                        if not abs_path:
+                            logger.warning("Skipping message without absolute_path")
+                            continue
+                        file_id = abs_path
+                        filename = doc.get("name")
+                        # Store file through DAL
+                        self.dal.store_file(file_id, abs_path, filename)
+                self.consumer.commit()
             except Exception as e:
                 logger.error(f"Consumer loop error: {e} Restarting consumer in 1s...")
                 try:
@@ -49,31 +47,5 @@ class MongoWriter:
                 except Exception:
                     pass
                 time.sleep(1)
-                self.consumer = Kafka_Connector.get_consumer(self.topic,"Mongowriter-metadata-group")
+                self.consumer = Kafka_Connector.get_consumer(self.topic, self.group_id)
                 continue
-
-    def _store_file(self, file_id: str, abs_path: str, filename: str, replace: bool = True):
-        """
-        Store a local file in MongoDB GridFS.
-        - file_id: unique identifier (we use absolute_path)
-        - abs_path: path on the disk
-        - replace: if True, delete existing GridFS file with same id
-        """
-        p = Path(abs_path)
-
-        # Ensure the file exist in the path
-        if not (p.exists() and p.is_file()):
-            logger.warning(f"File not found: {abs_path}")
-            return
-
-        # Ensure the file not already exist, otherwise we delete it to prevent duplicates
-        if replace and self.fs.exists({"_id": file_id}):
-            self.fs.delete(file_id)
-
-        with p.open("rb") as fh:
-            kwargs = {"_id": file_id}
-            if filename:
-                kwargs["filename"] = filename
-            self.fs.put(fh, **kwargs)
-
-        logger.info(f"Stored file in GridFS (id={file_id}, name={filename or p.name})")

--- a/services/transcription_service/src/service.py
+++ b/services/transcription_service/src/service.py
@@ -10,67 +10,74 @@ class TranscriptionService:
         config = load_config()
         self.input_topic = config["kafka"]["topics"]["raw_metadata"]
         self.output_topic = config["kafka"]["topics"]["transcribed_content"]
+        self.group_id = "transcription-service-group"
+        self.batch_size = config["kafka"].get("consumer_batch_size", 50)
+        self.timeout_ms = config["kafka"].get("consumer_timeout_ms", 1000)
 
         self.consumer = Kafka_Connector.get_consumer(
-            self.input_topic,
-            group_id="transcription-service-group"
+            self.input_topic, group_id=self.group_id
         )
         self.producer = Kafka_Connector.get_producer()
         self.dal = Transcriber()
-        self.index_name = "files_metadata"
-
+        # Index name from config to check for existing transcriptions
+        self.index_name = config["elasticsearch"]["indexes"]["files_metadata"]
 
     def run(self):
         logger.info("TranscriptionService started and waiting for messages...")
         while True:
             try:
-                for msg in self.consumer:
-                    doc = msg.value
-                    absolute_path = doc.get("absolute_path")
-
-                    if not absolute_path:
-                        logger.warning("Skipping message without absolute_path")
-                        continue
-
-                    # Check if it's an audio file
-                    if not self._is_audio_file(absolute_path):
-                        logger.debug(f"Skipping non-audio file: {absolute_path}")
-                        continue
-
-                    # Check if this document has a transcription
-                    # if self.dal.has_transcription(absolute_path,self.index_name):
-                    #     logger.info(f"Skipping already-transcribed file: {absolute_path}")
-                    #     continue
-
-                    try:
-                        # Transcribe the audio file
-                        transcription = self.dal.transcribe_audio_file(absolute_path)
-
-                        if transcription:
-                            # Send transcription to Kafka for ES indexer
-                            transcription_doc = {
-                                "absolute_path": absolute_path,
-                                "content": transcription,
-                                "message_type": "transcription"
-                            }
-
-                            self.producer.send(self.output_topic, transcription_doc)
-                            logger.info(f"Transcription completed and sent for: {absolute_path}")
-
-                    except Exception as e:
-                        logger.error(f"Failed to process transcription for {absolute_path}: {e}")
-
+                records = self.consumer.poll(
+                    timeout_ms=self.timeout_ms, max_records=self.batch_size
+                )
+                if not records:
+                    continue
+                for msgs in records.values():
+                    for msg in msgs:
+                        doc = msg.value
+                        absolute_path = doc.get("absolute_path")
+                        if not absolute_path:
+                            logger.warning("Skipping message without absolute_path")
+                            continue
+                        # Check if it's an audio file
+                        if not self._is_audio_file(absolute_path):
+                            logger.debug(f"Skipping non-audio file: {absolute_path}")
+                            continue
+                        # Skip already transcribed files
+                        if self.dal.has_transcription(absolute_path, self.index_name):
+                            logger.info(f"Skipping already-transcribed file: {absolute_path}")
+                            continue
+                        try:
+                            transcription = self.dal.transcribe_audio_file(absolute_path)
+                            if transcription:
+                                transcription_doc = {
+                                    "absolute_path": absolute_path,
+                                    "content": transcription,
+                                    "message_type": "transcription",
+                                }
+                                self.producer.send(self.output_topic, transcription_doc)
+                                logger.info(
+                                    f"Transcription completed and sent for: {absolute_path}"
+                                )
+                        except Exception as e:
+                            logger.error(
+                                f"Failed to process transcription for {absolute_path}: {e}"
+                            )
+                self.consumer.commit()
             except Exception as e:
-                logger.error(f"Consumer loop error: {e}. Restarting consumer in 1s...")
+                logger.error(
+                    f"Consumer loop error: {e}. Restarting consumer in 1s..."
+                )
                 try:
                     self.consumer.close()
                 except Exception:
                     pass
                 time.sleep(1)
-                self.consumer = Kafka_Connector.get_consumer(self.input_topic,"transcription-service-group")
+                self.consumer = Kafka_Connector.get_consumer(
+                    self.input_topic, self.group_id
+                )
                 continue
 
     def _is_audio_file(self, file_path: str) -> bool:
         """Check if the file is an audio file based on extension"""
-        audio_extensions = {'.mp3', '.wav', '.m4a', '.flac', '.aac', '.ogg', '.wma'}
+        audio_extensions = {".mp3", ".wav", ".m4a", ".flac", ".aac", ".ogg", ".wma"}
         return any(file_path.lower().endswith(ext) for ext in audio_extensions)

--- a/services/transcription_service/src/transcriber.py
+++ b/services/transcription_service/src/transcriber.py
@@ -1,16 +1,17 @@
 import os
 from faster_whisper import WhisperModel
 from shared.utils.logger import logger
-from elasticsearch import Elasticsearch, NotFoundError
-from dal .elastic_dal import Elastic_DAL
-
-
+import os
+from faster_whisper import WhisperModel
+from shared.utils.logger import logger
+from elasticsearch import NotFoundError
+from dal.elastic_dal import Elastic_DAL
 
 
 class Transcriber:
     def __init__(self):
         """Initialize the Whisper model"""
-        self.es = Elastic_DAL().es
+        self.dal = Elastic_DAL()
         try:
             logger.info("Initializing Whisper model...")
             self.whisper_model = WhisperModel(
@@ -30,9 +31,8 @@ class Transcriber:
         before we're starting to transcribe
         """
         try:
-            res = self.es.get(index=index_name, id=absolute_path)
-            src = res.get("_source", {})
-            return bool(src.get("content") != " ")
+            doc = self.dal.get_by_id(index_name, absolute_path)
+            return bool(doc.get("content"))
         except NotFoundError:
             return False
         except Exception as e:

--- a/shared/config/config.yaml
+++ b/shared/config/config.yaml
@@ -12,6 +12,10 @@ elasticsearch:
 
 kafka:
   bootstrap_servers: "localhost:9092"
+  # Polling timeout for consumers (ms)
+  consumer_timeout_ms: 1000
+  # Number of records processed before committing offsets
+  consumer_batch_size: 50
   topics:
     raw_metadata: "raw-metadata"
     transcribed_content: "transcribed-content"

--- a/shared/connectors/kafka_connector.py
+++ b/shared/connectors/kafka_connector.py
@@ -1,5 +1,3 @@
-from asyncio import timeout
-
 from kafka import KafkaProducer, KafkaConsumer
 import json
 from shared.utils.config_loader import load_config
@@ -9,8 +7,10 @@ class Kafka_Connector:
     @staticmethod
     def get_producer():
         config = load_config()
-        return KafkaProducer( bootstrap_servers=config["kafka"]["bootstrap_servers"],
-                             value_serializer=lambda v: json.dumps(v).encode("utf-8"))
+        return KafkaProducer(
+            bootstrap_servers=config["kafka"]["bootstrap_servers"],
+            value_serializer=lambda v: json.dumps(v).encode("utf-8")
+        )
 
 
     @staticmethod
@@ -23,11 +23,14 @@ class Kafka_Connector:
             group_id: Optional group ID
         """
         config = load_config()
+        timeout_ms = config["kafka"].get("consumer_timeout_ms", 1000)
 
         return KafkaConsumer(
             topic,
             bootstrap_servers=config["kafka"]["bootstrap_servers"],
             group_id=group_id,
             value_deserializer=lambda v: json.loads(v.decode("utf-8")),
-            consumer_timeout_ms=50000
+            enable_auto_commit=False,  # manual commit for reliable processing
+            auto_offset_reset="earliest",
+            consumer_timeout_ms=timeout_ms
         )


### PR DESCRIPTION
## Summary
- manage Kafka offsets with manual poll/commit and stable consumer groups
- move MongoDB/GridFS and Elasticsearch settings to shared config and DALs
- skip already-transcribed audio and batch index documents via ES bulk API

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c1f1e8a1a88331a30b413b3e9f87b2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Configurable Kafka batching and timeouts with manual offset commits across services.
  - Bulk Elasticsearch indexing for metadata; batch updates for transcriptions.
  - GridFS file storage via a Mongo data layer.
- Refactor
  - Replaced hard-coded consumer groups and index names with configuration.
  - Migrated services to DAL-backed operations for Elasticsearch and MongoDB.
- Documentation
  - Added “Batching and offsets” guidance to README.
- Chores
  - Added Kafka consumer settings to shared config.
  - Streamlined connectors for manual commits and GridFS access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->