### PR TITLE
feat: make danger threshold configurable

### DIFF
--- a/services/hostility_detection_service/src/service.py
+++ b/services/hostility_detection_service/src/service.py
@@ -23,7 +23,7 @@ class HostilityDetector:
         self.index_name = cfg["elasticsearch"]["indexes"]["hostility_results"]
 
         # Set threshold for flagging messages
-        self.DANGER_THRESHOLD = 15.0
+        self.DANGER_THRESHOLD = cfg.get("hostility_detection", {}).get("danger_threshold", 15.0)
 
         self.analyzer = Analyzer()
 

--- a/shared/config/config.yaml
+++ b/shared/config/config.yaml
@@ -23,3 +23,6 @@ kafka:
 
 files:
   path: "C:\\podcasts"
+
+hostility_detection:
+  danger_threshold: 15.0


### PR DESCRIPTION
## Summary
- add `danger_threshold` option to configuration
- read danger threshold from config in hostility detector service

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c2b232362c8331a49e1c66148e9fc6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a configurable danger threshold for hostility detection, allowing you to tune sensitivity to match your risk tolerance or environment.
  * The system defaults to the previous threshold if no value is provided, preserving existing behavior.
  * Configuration is managed through the central settings, requiring no code changes or updates to integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->