### PR TITLE
Make hostility danger threshold configurable

### DIFF
--- a/services/hostility_detection_service/src/service.py
+++ b/services/hostility_detection_service/src/service.py
@@ -23,7 +23,7 @@ class HostilityDetector:
         self.index_name = cfg["elasticsearch"]["indexes"]["hostility_results"]
 
         # Set threshold for flagging messages
-        self.DANGER_THRESHOLD = 15.0
+        self.DANGER_THRESHOLD = cfg.get("hostility_detection", {}).get("danger_threshold", 15.0)
 
         self.analyzer = Analyzer()
 

--- a/shared/config/config.yaml
+++ b/shared/config/config.yaml
@@ -23,3 +23,6 @@ kafka:
 
 files:
   path: "C:\\podcasts"
+
+hostility_detection:
+  danger_threshold: 15.0


### PR DESCRIPTION
## Summary
- Add `danger_threshold` setting under new `hostility_detection` section in shared config
- Read danger threshold from configuration in hostility detection service instead of hardcoded value

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c29f7bec18833183d3c3e50e0baeb1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Hostility detection sensitivity is now configurable via app settings, allowing admins to adjust the danger threshold as needed.
  * Default behavior remains unchanged for users who do not modify settings.

* **Chores**
  * Added a new configuration block for hostility detection with a default danger threshold value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->