### PR TITLE
Handle empty transcriptions and clean loader content

### DIFF
--- a/services/retriever_service/src/data_loader.py
+++ b/services/retriever_service/src/data_loader.py
@@ -28,7 +28,7 @@ class Files_Loader:
                     "absolute_path": str(file.resolve()),
                     "created": time.ctime(stats.st_ctime),
                     "modified": time.ctime(stats.st_mtime),
-                    "content": " "
+                    "content": ""
                 })
                 logger.info(f"Loaded metadata for {file.name}")
         return records

--- a/services/transcription_service/src/transcriber.py
+++ b/services/transcription_service/src/transcriber.py
@@ -32,7 +32,7 @@ class Transcriber:
         """
         try:
             doc = self.dal.get_by_id(index_name, absolute_path)
-            return bool(doc.get("content"))
+            return bool(doc.get("content") and doc["content"].strip())
         except NotFoundError:
             return False
         except Exception as e:


### PR DESCRIPTION
## Summary
- ensure whitespace-only content isn't treated as a transcription
- avoid placeholder whitespace in file metadata

## Testing
- `pytest`
- `python -m py_compile services/transcription_service/src/transcriber.py services/retriever_service/src/data_loader.py`


------
https://chatgpt.com/codex/tasks/task_e_68c2918327b08331a2dc4065a7227368

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Transcriptions: Whitespace-only content is no longer treated as a valid transcription, improving status accuracy and allowing proper reprocessing of empty results.
  * File metadata: Default content is now truly empty (not a placeholder space), preventing stray blanks in previews and improving downstream whitespace handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->