### PR TITLE
Avoid duplicate transcriptions and improve ES/Kafka handling

### DIFF
--- a/dal/elastic_dal.py
+++ b/dal/elastic_dal.py
@@ -27,8 +27,12 @@ class Elastic_DAL:
                 logger.info(f"Document CREATED in {index_name}: {doc_id}")
             elif result == "updated":
                 logger.info(f"Document UPDATED in {index_name}: {doc_id}")
+            elif result == "noop":
+                logger.info(f"Document NOOP (unchanged) in {index_name}: {doc_id}")
             else:
-                logger.warning(f"Unexpected result for {doc_id} in {index_name}: {result}")
+                logger.warning(
+                    f"Unexpected result for {doc_id} in {index_name}: {result}"
+                )
 
         except Exception as e:
             logger.error(f"Failed to index/update doc {doc_id}: {e}")

--- a/services/transcription_service/src/service.py
+++ b/services/transcription_service/src/service.py
@@ -47,8 +47,15 @@ class TranscriptionService:
                             logger.debug(f"Skipping non-audio file: {absolute_path}")
                             continue
 
-                        if self.transcriber and self.transcriber.has_transcription(absolute_path, self.output_topic):
-                            logger.info(f"Skipping already-transcribed file: {absolute_path}")
+                        if (
+                            self.transcriber
+                            and self.transcriber.has_transcription(
+                                absolute_path, self.index_name
+                            )
+                        ):
+                            logger.info(
+                                f"Skipping already-transcribed file: {absolute_path}"
+                            )
                             continue
 
                         try:

--- a/shared/config/config.yaml
+++ b/shared/config/config.yaml
@@ -15,6 +15,7 @@ kafka:
   consumer_timeout_ms: 1000
   # Number of records processed before committing offsets
   consumer_batch_size: 50
+  auto_offset_reset: latest
   topics:
     raw_metadata: "raw-metadata"
     transcribed_content: "transcribed-content"

--- a/shared/connectors/kafka_connector.py
+++ b/shared/connectors/kafka_connector.py
@@ -28,6 +28,7 @@ class Kafka_Connector:
             config = load_config()
             servers = config["kafka"]["bootstrap_servers"]
             timeout_ms = config["kafka"].get("consumer_timeout_ms", 1000)
+            offset_reset = config["kafka"].get("auto_offset_reset", "latest")
             logger.info(f"Creating Kafka consumer for topic: {topic}")
             return KafkaConsumer(
                 topic,
@@ -35,8 +36,8 @@ class Kafka_Connector:
                 group_id=group_id,
                 value_deserializer=lambda v: json.loads(v.decode("utf-8")),
                 enable_auto_commit=False,
-                auto_offset_reset="earliest",
-                consumer_timeout_ms=timeout_ms
+                auto_offset_reset=offset_reset,
+                consumer_timeout_ms=timeout_ms,
             )
         except Exception as e:
             logger.error(f"Error creating Kafka consumer: {e}")


### PR DESCRIPTION
## Summary
- prevent reprocessing of already transcribed files by checking Elasticsearch index
- log Elasticsearch no-op updates as informational instead of warnings
- allow Kafka consumer auto offset reset to be configured via config (default latest)

## Testing
- `python -m py_compile dal/elastic_dal.py services/transcription_service/src/service.py shared/connectors/kafka_connector.py`


------
https://chatgpt.com/codex/tasks/task_e_68c60240077483319fea9a65aa76858e