### PR TITLE
Allow configurable overwriting for GridFS files

### DIFF
--- a/dal/mongo_dal.py
+++ b/dal/mongo_dal.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 from shared.connectors.mongo_connector import Mongo_Connector
+from shared.utils.config_loader import load_config
 from shared.utils.logger import logger
 
 
@@ -17,17 +18,30 @@ class Mongo_Dal:
     def get_all_docs(self):
         return list(self.coll.find().limit(20))
 
-    def store_file(self, file_id: str, abs_path: str, filename: str, replace: bool = True):
+    def store_file(
+        self,
+        file_id: str,
+        abs_path: str,
+        filename: str,
+        replace: bool | None = None,
+    ):
         """Store a local file in GridFS via the DAL."""
         p = Path(abs_path)
         if not (p.exists() and p.is_file()):
             logger.warning(f"File not found: {abs_path}")
             return
+
+        if replace is None:
+            replace = load_config().get("files", {}).get("replace", True)
+
         if replace and self.fs.exists({"_id": file_id}):
             self.fs.delete(file_id)
+
         with p.open("rb") as fh:
             kwargs = {"_id": file_id}
             if filename:
                 kwargs["filename"] = filename
             self.fs.put(fh, **kwargs)
-        logger.info(f"Stored file in GridFS (id={file_id}, name={filename or p.name})")
+        logger.info(
+            f"Stored file in GridFS (id={file_id}, name={filename or p.name})"
+        )

--- a/shared/config/config.yaml
+++ b/shared/config/config.yaml
@@ -23,6 +23,7 @@ kafka:
 
 files:
   path: "C:\\podcasts"
+  replace: true
 
 hostility_detection:
   danger_threshold: 12.0

--- a/shared/utils/config_loader.py
+++ b/shared/utils/config_loader.py
@@ -44,9 +44,18 @@ def load_config():
             config["kafka"]["topics"] = {}
         config["kafka"]["topics"]["raw_metadata"] = kafka_topic_raw
 
-    # Files path overrides
+    # Files overrides
     files_path = os.getenv("FILES_PATH")
     if files_path:
         config["files"]["path"] = files_path
+
+    files_replace = os.getenv("FILES_REPLACE")
+    if files_replace is not None:
+        config["files"]["replace"] = files_replace.lower() in (
+            "1",
+            "true",
+            "yes",
+            "on",
+        )
 
     return config


### PR DESCRIPTION
## Summary
- Enable config-driven control over file replacement in `Mongo_Dal.store_file`
- Support `FILES_REPLACE` env var and config setting
- Default `files.replace` to true in `config.yaml`

## Testing
- `python -m py_compile dal/mongo_dal.py shared/utils/config_loader.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c612a9bd248331b7af2fffef496d5a