### PR TITLE
feat: make existing transcription skip configurable

### DIFF
--- a/services/transcription_service/src/service.py
+++ b/services/transcription_service/src/service.py
@@ -23,6 +23,10 @@ class TranscriptionService:
         self.transcriber = Transcriber()
         # Index name from config to check for existing transcriptions
         self.index_name = config["elasticsearch"]["indexes"]["files_metadata"]
+        # Whether to skip files that already have a transcription
+        self.skip_existing_transcriptions = config.get(
+            "skip_existing_transcriptions", True
+        )
 
     def run(self) -> None:
         logger.info("TranscriptionService started and waiting for messages...")
@@ -48,7 +52,8 @@ class TranscriptionService:
                             continue
 
                         if (
-                            self.transcriber
+                            self.skip_existing_transcriptions
+                            and self.transcriber
                             and self.transcriber.has_transcription(
                                 absolute_path, self.index_name
                             )

--- a/shared/config/config.yaml
+++ b/shared/config/config.yaml
@@ -26,3 +26,6 @@ files:
 
 hostility_detection:
   danger_threshold: 12.0
+
+# Transcription service options
+skip_existing_transcriptions: true


### PR DESCRIPTION
## Summary
- add `skip_existing_transcriptions` option to config
- allow transcription service to skip or reprocess existing entries based on config

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c612a9d75483318ca2c9a77c7e8bf5